### PR TITLE
Patch Log4j RCE.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.3-jdk-8
+FROM maven:3.8-jdk-8
 
 RUN mkdir -p /usr/src/app/
 WORKDIR /usr/src/app
@@ -9,4 +9,4 @@ RUN mvn clean && mvn package
 # cache directory for player skins; TODO customize the path in the future
 RUN mkdir -p /root/.chunky/cache
 
-ENTRYPOINT ["java","-jar","/usr/src/app/target/rendernode-1.4.0-jar-with-dependencies.jar","--job-path","/usr/local/rendernode/rs_jobs","--texturepacks-path","/usr/src/app/texturepacks"]
+ENTRYPOINT ["java","-jar","/usr/src/app/target/rendernode-1.4.1-jar-with-dependencies.jar","--job-path","/usr/local/rendernode/rs_jobs","--texturepacks-path","/usr/src/app/texturepacks"]

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>de.lemaik.chunkycloud</groupId>
   <artifactId>rendernode</artifactId>
-  <version>1.4.0</version>
+  <version>1.4.1</version>
 
   <licenses>
     <license>
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.0.2</version>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>com.lexicalscope.jewelcli</groupId>


### PR DESCRIPTION
Update log4j to 2.15.0. Update Java to 1.8u312. Bump version to 1.4.1.