### PR TITLE
Switch to SLF4J & update Log4J to 2.17.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.17.0</version>
+      <artifactId>log4j-slf4j18-impl</artifactId>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>com.lexicalscope.jewelcli</groupId>

--- a/src/main/java/de/lemaik/renderservice/renderer/Main.java
+++ b/src/main/java/de/lemaik/renderservice/renderer/Main.java
@@ -24,7 +24,7 @@ import de.lemaik.renderservice.renderer.application.CommandlineArguments;
 import de.lemaik.renderservice.renderer.application.HeadlessRenderer;
 import de.lemaik.renderservice.renderer.application.RendererSettings;
 import de.lemaik.renderservice.renderer.chunky.FilteringLogReceiver;
-import de.lemaik.renderservice.renderer.chunky.Log4jLogReceiver;
+import de.lemaik.renderservice.renderer.chunky.Slf4jLogReceiver;
 import java.util.Optional;
 import se.llbit.log.Level;
 import se.llbit.log.Log;
@@ -38,7 +38,7 @@ public class Main {
   public static final int API_VERSION = 1;
 
   static {
-    Log.setReceiver(new FilteringLogReceiver(new Log4jLogReceiver()), Level.ERROR, Level.WARNING,
+    Log.setReceiver(new FilteringLogReceiver(new Slf4jLogReceiver()), Level.ERROR, Level.WARNING,
         Level.INFO);
   }
 

--- a/src/main/java/de/lemaik/renderservice/renderer/application/HeadlessRenderer.java
+++ b/src/main/java/de/lemaik/renderservice/renderer/application/HeadlessRenderer.java
@@ -18,11 +18,11 @@
 
 package de.lemaik.renderservice.renderer.application;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HeadlessRenderer extends RendererApplication {
-    private static final Logger LOGGER = LogManager.getLogger(HeadlessRenderer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HeadlessRenderer.class);
 
     public HeadlessRenderer(RendererSettings settings) {
         super(settings);

--- a/src/main/java/de/lemaik/renderservice/renderer/application/RendererApplication.java
+++ b/src/main/java/de/lemaik/renderservice/renderer/application/RendererApplication.java
@@ -35,15 +35,15 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okio.BufferedSink;
 import okio.Okio;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.llbit.chunky.PersistentSettings;
 
 public abstract class RendererApplication {
 
   private static final int VERSION = 3;
   private static final String TEXTURE_VERSION = "1.17.1";
-  private static final Logger LOGGER = LogManager.getLogger(RendererApplication.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(RendererApplication.class);
 
   private final RenderServerApiClient api;
   private final RendererSettings settings;

--- a/src/main/java/de/lemaik/renderservice/renderer/chunky/Slf4jLogReceiver.java
+++ b/src/main/java/de/lemaik/renderservice/renderer/chunky/Slf4jLogReceiver.java
@@ -1,16 +1,17 @@
 package de.lemaik.renderservice.renderer.chunky;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.llbit.log.Level;
 import se.llbit.log.Receiver;
 
 /**
- * An adapter between Log4J and Chunky's logger.
+ * An adapter from Chunky's logger to Slf4J.
  */
-public class Log4jLogReceiver extends Receiver {
+public class Slf4jLogReceiver extends Receiver {
 
-  private static final Logger LOGGER = LogManager.getLogger("Chunky");
+  private static final Logger LOGGER = LoggerFactory.getLogger("Chunky");
 
   @Override
   public void logEvent(Level level, String message) {

--- a/src/main/java/de/lemaik/renderservice/renderer/rendering/RenderWorker.java
+++ b/src/main/java/de/lemaik/renderservice/renderer/rendering/RenderWorker.java
@@ -24,6 +24,10 @@ import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.QueueingConsumer;
 import de.lemaik.renderservice.renderer.Main;
 import de.lemaik.renderservice.renderer.chunky.ChunkyWrapperFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -34,15 +38,13 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  * A renderer worker thread.
  */
 public class RenderWorker extends Thread {
 
-  private static final Logger LOGGER = LogManager.getLogger(RenderWorker.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(RenderWorker.class);
   private static final String QUEUE_NAME = "rs_tasks_241";
   private final ExecutorService executorService;
   private final Path jobDirectory;

--- a/src/main/java/de/lemaik/renderservice/renderer/rendering/TaskWorker.java
+++ b/src/main/java/de/lemaik/renderservice/renderer/rendering/TaskWorker.java
@@ -39,12 +39,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 import javax.imageio.ImageIO;
 import okhttp3.Response;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TaskWorker implements Runnable {
 
-  private static final Logger LOGGER = LogManager.getLogger(TaskWorker.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(TaskWorker.class);
   private static final Gson gson = new Gson();
 
   private final QueueingConsumer.Delivery delivery;


### PR DESCRIPTION
Updated Log4J (again) and switch to SLF4J so we can switch logging frameworks more easily in the future.